### PR TITLE
Limit number of pump doses in a watering cycle

### DIFF
--- a/lib/watering/watering.h
+++ b/lib/watering/watering.h
@@ -31,6 +31,9 @@ class Watering : public Module {
     //  go back to kStateEval.
     kStateWaitForNextCycle,
 
+    // After too many does in a cycle, pause for 12 hours.
+    kStateWateringPaused,
+
     // State for when pump is disabled.
     kStateDisabled,
 
@@ -120,9 +123,11 @@ class Watering : public Module {
   FloatVariable m_pump_dose_msec;
   FloatVariable m_between_doses_sec;
   StateVariable m_state;
+  FloatVariable m_sec_since_dose;
+  Variable<unsigned> m_max_doses_per_cycle;
+  Variable<unsigned> m_doses_this_cycle;
   BoolVariable m_watering_enabled;
   BoolVariable m_reservoir_check_enabled;
-  FloatVariable m_sec_since_dose;
 };
 
 }  // namespace og3

--- a/lib/watering/watering_constants.h
+++ b/lib/watering/watering_constants.h
@@ -31,4 +31,8 @@ constexpr unsigned kFullMoistureCounts = 1470;
 // Default ADC reading at which to consider soil moisture to be 0%.
 constexpr unsigned kNoMoistureCounts = 2900;
 
+constexpr unsigned kMaxDosesPerCycle = 5;
+
+constexpr unsigned kWateringPauseMsec = 12 * kMsecInHour;
+
 }  // namespace og3


### PR DESCRIPTION
If there are too many pump doses in watering cycle, then switch to a "watering paused" state and wait for 12 hours.  This is a safety features to avoid over-watering if something goes wrong, such as unreliable moisture sensor readings.