### PR TITLE
Set AP password

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,14 +28,14 @@ build_type = release
 ;	~/Projects2/Plant133/lib/watering
 lib_deps =
         watering
-	og3@^0.2.2
+	og3@^0.2.3
 	og3x-oled@^0.2.2
 	og3x-shtc3@^0.2.0
 	adafruit/Adafruit BusIO
 	adafruit/Adafruit SHTC3 Library
 	adafruit/Adafruit Unified Sensor
 	bblanchon/ArduinoJson@^7.0.0
-	ottowinter/AsyncMqttClient-esphome@ ^0.8.5
+	heman/AsyncMqttClient-esphome@^1.0.0
 	esphome/ESPAsyncWebServer-esphome@^3.0.0
 	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.0
 	Wire
@@ -48,6 +48,7 @@ build_flags =
 ;	'-D LOG_UDP'
 	'-D WIFI_OLED'
 	'-D LOG_UDP_ADDRESS=${secrets.udpLogTarget}'
+	'-D AP_PASSWORD="${secrets.apPassword}"'
 
 upload_protocol = ${secrets.uploadProtocol}
 upload_port = ${secrets.uploadPort}

--- a/secrets.ini.example
+++ b/secrets.ini.example
@@ -3,3 +3,6 @@
 udpLogTarget = 192, 168, 0, 20
 # Add a password for other-the-air password updates.
 otaPassword = {password-here}
+# Add a password for the Soft-AP mode.
+# This will allow soft-AP Wifi to be encrypted.
+apPassword = {password-here}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 
 #include "watering.h"
 
-#define SW_VERSION "0.7.3"
+#define SW_VERSION "0.7.4"
 
 namespace {
 
@@ -44,6 +44,9 @@ og3::HAApp s_app(
                             .withSoftwareName(kSoftware)
                             .withDefaultDeviceName("plant133")
                             .withOta(og3::OtaManager::Options(OTA_PASSWORD))
+#if defined(AP_PASSWORD)
+                            .withWifi(og3::WifiManager::Options().withApPassword(AP_PASSWORD))
+#endif
 #if defined(LOG_UDP) && defined(LOG_UDP_ADDRESS)
                             .withApp(og3::App::Options().withLogType(og3::App::LogType::kUdp))
                             .withUdpLogHost(IPAddress(IPAddress(LOG_UDP_ADDRESS)))


### PR DESCRIPTION
- If specified in secrets.ini, set a password on the soft-AP.
- Also, switch mqtt client library to that used by ESPHome.