### PR TITLE
Fix limiting doses in 24 hours.

### DIFF
--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -10,14 +10,14 @@
 namespace og3 {
 namespace {
 constexpr unsigned kCfgSet = VariableBase::Flags::kConfig | VariableBase::Flags::kSettable;
-constexpr long kSecInHour = kSecInMin * 60;
 }  // namespace
 
-DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg)
+DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system)
     : m_max_doses_per_cycle("max_doses_per_cycle", kMaxDosesPerCycle, "", "maximum doses per cycle",
                             kCfgSet, cfg_vg),
       m_doses_this_cycle("doses_this_cycle", 0, "", "doses this cycle", 0, vg),
-      m_dose_count("doses_today", 0, "", "doses in the past day", 0, vg) {}
+      m_dose_count("doses_today", 0, "", "doses in the past day", 0, vg),
+      m_module_system(module_system) {}
 
 void DoseLog::addHADiscovery(HADiscovery* had) {
   had->addDiscoveryCallback([this](HADiscovery* had, JsonDocument* json) {
@@ -38,38 +38,35 @@ bool DoseLog::shouldPauseWatering() const {
   return false;
 }
 
-void DoseLog::startWatering() {
-  if (!m_watering) {
-    m_dose_record.pushBack({});
-    m_watering = true;
-  }
-}
 void DoseLog::addDose() {
   m_dose_record.back().dose_count += 1;
   m_dose_count = m_dose_count.value() + 1;
   m_doses_this_cycle = m_doses_this_cycle.value() + 1;
 }
-void DoseLog::stopWatering() {
-  if (m_watering) {
-    m_doses_this_cycle = 0;
-    m_watering = false;
-  }
-}
 
-void DoseLog::update() {
-  if (m_watering) {
-    return;
-  }
-  const int64_t now_secs = esp_timer_get_time() / kUsecInSec;
-  const int64_t one_day_ago =
-      std::max(static_cast<int64_t>(0), static_cast<int64_t>(now_secs) - kSecInHour * 24);
-  while (!m_dose_record.empty()) {
-    const auto front = m_dose_record.front();
-    if (front.secs > one_day_ago) {
-      break;  // While dose record is not yet a day old, don't remove it.
+void DoseLog::update(bool is_watering) {
+  if (m_watering != is_watering) {
+    if (is_watering) {
+      m_dose_record.pushBack({});
+    } else {
+      m_doses_this_cycle = 0;
     }
-    m_dose_count = std::max(0, static_cast<int>(m_dose_count.value()) - front.dose_count);
-    m_dose_record.popFront();
+    m_watering = is_watering;
+  }
+
+  if (!m_watering) {
+    const int64_t now_secs = esp_timer_get_time() / kUsecInSec;
+    const int64_t one_day_ago = std::max(static_cast<int64_t>(0), now_secs - kSecInDay);
+    while (!m_dose_record.empty()) {
+      const auto front = m_dose_record.front();
+      if (front.secs > one_day_ago) {
+        break;  // While dose record is not yet a day old, don't remove it.
+      }
+      log()->logf("Popping dose record (%zu left): %lld > %lld", m_dose_record.size() - 1,
+                  front.secs, one_day_ago);
+      m_dose_count = std::max(0, static_cast<int>(m_dose_count.value()) - front.dose_count);
+      m_dose_record.popFront();
+    }
   }
 }
 

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -54,7 +54,7 @@ void DoseLog::update(bool is_watering) {
     m_watering = is_watering;
   }
 
-  if (!m_watering) {
+  if (!m_watering && !m_dose_record.empty()) {
     const int64_t now_secs = esp_timer_get_time() / kUsecInSec;
     const int64_t one_day_ago = std::max(static_cast<int64_t>(0), now_secs - kWateringPauseSec);
     while (!m_dose_record.empty()) {
@@ -62,7 +62,7 @@ void DoseLog::update(bool is_watering) {
       if (front.secs > one_day_ago) {
         break;  // While dose record is not yet a day old, don't remove it.
       }
-      log()->logf("Popping dose record (%zu left): %lld > %lld", m_dose_record.size() - 1,
+      log()->logf("Popping dose record (%zu left): %lld sec > %lld.", m_dose_record.size() - 1,
                   front.secs, one_day_ago);
       m_dose_count = std::max(0, static_cast<int>(m_dose_count.value()) - front.dose_count);
       m_dose_record.popFront();

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -56,7 +56,7 @@ void DoseLog::update(bool is_watering) {
 
   if (!m_watering) {
     const int64_t now_secs = esp_timer_get_time() / kUsecInSec;
-    const int64_t one_day_ago = std::max(static_cast<int64_t>(0), now_secs - kSecInDay);
+    const int64_t one_day_ago = std::max(static_cast<int64_t>(0), now_secs - kWateringPauseSec);
     while (!m_dose_record.empty()) {
       const auto front = m_dose_record.front();
       if (front.secs > one_day_ago) {

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -1,3 +1,4 @@
+#include <og3/constants.h>
 #include <og3/ring_buffer.h>
 #include <og3/util.h>
 #include <og3/variable.h>
@@ -5,6 +6,8 @@
 #include <algorithm>
 
 namespace og3 {
+
+const uint64_t kUsecInSec = 1000 * 1000;
 
 // Track the total number of watering doses in a day.
 // This is done to avoid over-watering in case something goes wrong such as problems
@@ -43,9 +46,8 @@ class DoseLog {
 
   // Doses in watering cycles in the last 24 hours.
   struct Dose {
-    Dose() {}
-    explicit Dose(unsigned long millis) { this->millis = millis; }
-    unsigned long millis = 0;
+    Dose() { this->secs = esp_timer_get_time() / kUsecInSec; }
+    uint64_t secs = 0;
     int doses_this_cycle = 0;
     int dose_count = 0;
   };

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -22,7 +22,8 @@ class DoseLog {
   //  a 24 hour period is reached, pause watering for 12 hours.
   bool shouldPauseWatering() const;
 
-  // Call this when the current watering cycle has ended.
+  // Call this each time the watering state machine is updated to add a watering-dose
+  //  entry when watering starts, and to expire watering doses after 24 hours.
   void update(bool is_watering);
   // Call this is increment the count of pump doses in the current watering cycle.
   // This should only be called if is_watering.

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -352,14 +352,10 @@ void Watering::setState(State state, unsigned msec, const char* msg) {
     // The watering state changed.
     log()->logf("plant%u: %s -> %s in %d.%03d: %s.", m_index, s_state_names[m_state.value()],
                 s_state_names[state], msec / 1000, msec % 1000, msg);
-    if (!isWatering(m_state.value())) {
-      if (isWatering(state)) {
-        m_dose_log.startWatering();  // Switched from not watering -> watering.
-      }
+    if (isWatering(state)) {
+      m_dose_log.startWatering();
     } else {
-      if (!isWatering(state)) {
-        m_dose_log.stopWatering();  // Switched from watering -> not watering.
-      }
+      m_dose_log.stopWatering();
     }
   } else {
     // The watering state is staying the same.

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -190,7 +190,8 @@ void Watering::loop() {
     m_reservoir_check->read();
   }
 
-  // Let dose log remove records more than a day old.
+  // Add a new dose record if newly watering, and expire dose records more than a day old
+  //  when not watering.
   m_dose_log.update(isWatering(state()));
 
   const long msecSincePump = nowMsec - m_pump.lastOnMsec();

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -297,12 +297,12 @@ void Watering::loop() {
         //  where we wait for it to fall back below the minimum to start the
         //  watering cycle again.
         setState(kStateWaitForNextCycle, kWaitForNextCycleMsec, "moisture past maximum range");
-      } else if (msecSincePump >= kWateringPauseMsec) {
+      } else if (m_dose_log.shouldPauseWatering()) {
+        // Stay in the paused state until it times-out.
+        setState(kStateWateringPaused, kWaitForNextCycleMsec, "");
+      } else {
         // If the pause time expires, go back to eval state.
         setState(kStateEval, 1, "re-enable watering after pause");
-      } else {
-        // Otherwise stay in the paused state.
-        setState(kStateWateringPaused, kWaitForNextCycleMsec, "");
       }
       break;
     }

--- a/lib/watering/watering_constants.h
+++ b/lib/watering/watering_constants.h
@@ -33,6 +33,6 @@ constexpr unsigned kNoMoistureCounts = 2900;
 
 constexpr unsigned kMaxDosesPerCycle = 5;
 
-constexpr unsigned kWateringPauseMsec = 12 * kMsecInHour;
+constexpr unsigned kWateringPauseSec = kSecInDay;
 
 }  // namespace og3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 
 #include "watering.h"
 
-#define SW_VERSION "0.7.4"
+#define SW_VERSION "0.8.0"
 
 namespace {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 
 #include "watering.h"
 
-#define SW_VERSION "0.8.0"
+#define SW_VERSION "0.8.1"
 
 namespace {
 


### PR DESCRIPTION
Use 64-bit clock values to avoid problems with value rollover.