### PR TITLE
Version 0.8.3

### DIFF
--- a/.github/workflows/copyright-header-check.yaml
+++ b/.github/workflows/copyright-header-check.yaml
@@ -9,4 +9,4 @@ jobs:
       - name: Install license-header-checker
         run: curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
       - name: Run license check
-        run: ./bin/license-header-checker -a -r -i git,.github,.pio ./util/license_header.txt . h cpp scad && [[ -z `git status -s` ]]
+        run: ./bin/license-header-checker -a -r -i git,.github,.pio ./util/license_header.txt . h cpp scad

--- a/.github/workflows/copyright-header-check.yaml
+++ b/.github/workflows/copyright-header-check.yaml
@@ -5,9 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Install license-header-checker
         run: curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
       - name: Run license check
-#        run: ./bin/license-header-checker -a -r -i git,.github,.pio ./util/license_header.txt . h cpp scad && [[ -z `git status -s` ]]
-        run: ./bin/license-header-checker -a -r -i git,.github,.pio ./util/license_header.txt . h cpp scad
+        run: ./bin/license-header-checker -a -r -i testdata ./license_header.txt . go && [[ -z `git status -s` ]]

--- a/.github/workflows/copyright-header-check.yaml
+++ b/.github/workflows/copyright-header-check.yaml
@@ -9,4 +9,4 @@ jobs:
       - name: Install license-header-checker
         run: curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
       - name: Run license check
-        run: ./bin/license-header-checker -a -r -i testdata ./util/license_header.txt . go && [[ -z `git status -s` ]]
+        run: ./bin/license-header-checker -a -r -i git,.github,.pio ./util/license_header.txt . h cpp scad && [[ -z `git status -s` ]]

--- a/.github/workflows/copyright-header-check.yaml
+++ b/.github/workflows/copyright-header-check.yaml
@@ -9,4 +9,4 @@ jobs:
       - name: Install license-header-checker
         run: curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
       - name: Run license check
-        run: ./bin/license-header-checker -a -r -i testdata ./license_header.txt . go && [[ -z `git status -s` ]]
+        run: ./bin/license-header-checker -a -r -i testdata ./util/license_header.txt . go && [[ -z `git status -s` ]]

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ secrets*.yaml
 *.old
 *.3mf
 /KiCAD/Plant1337-backups/
+/compile_commands.json
+/.cache/

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -11,14 +11,22 @@
 namespace og3 {
 namespace {
 constexpr unsigned kCfgSet = VariableBase::Flags::kConfig | VariableBase::Flags::kSettable;
+
 }  // namespace
+
+const char* DoseLog::varname(const char* elname, const VariableGroup& vg, std::string* str) {
+  *str = std::string(vg.name()) + "_" + elname;
+  return str->c_str();
+}
 
 DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system,
                  Watering* watering)
     : m_max_doses_per_cycle("max_doses_per_cycle", kMaxDosesPerCycle, "", "maximum doses per cycle",
                             kCfgSet, cfg_vg),
-      m_doses_this_cycle("doses_this_cycle", 0, "", "doses this cycle", 0, vg),
-      m_dose_count("doses_today", 0, "", "doses in the past day", 0, vg),
+      m_doses_this_cycle(varname("doses_this_cycle", vg, &m_str_doses_this_cycle), 0, "",
+                         "doses this cycle", 0, vg),
+      m_dose_count(varname("doses_today", vg, &m_str_doses_today), 0, "", "doses in the past day",
+                   0, vg),
       m_module_system(module_system),
       m_watering(watering) {}
 

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -12,11 +12,18 @@ namespace {
 constexpr unsigned kCfgSet = VariableBase::Flags::kConfig | VariableBase::Flags::kSettable;
 }  // namespace
 
+const char* DoseLog::varname(const char* elname, const VariableGroup& vg, std::string* str) {
+  *str = std::string(vg.name()) + "_" + elname;
+  return str->c_str();
+}
+
 DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system)
     : m_max_doses_per_cycle("max_doses_per_cycle", kMaxDosesPerCycle, "", "maximum doses per cycle",
                             kCfgSet, cfg_vg),
-      m_doses_this_cycle("doses_this_cycle", 0, "", "doses this cycle", 0, vg),
-      m_dose_count("doses_today", 0, "", "doses in the past day", 0, vg),
+      m_doses_this_cycle(varname("doses_this_cycle", vg, &m_str_doses_this_cycle), 0, "",
+                         "doses this cycle", 0, vg),
+      m_dose_count(varname("doses_today", vg, &m_str_doses_today), 0, "", "doses in the past day",
+                   0, vg),
       m_module_system(module_system) {}
 
 void DoseLog::addHADiscovery(HADiscovery* had) {

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Chris Lee and contibuters.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
 #include "dose_log.h"
 
 #include <og3/constants.h>

--- a/lib/watering/dose_log.cpp
+++ b/lib/watering/dose_log.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "watering.h"
 #include "watering_constants.h"
 
 namespace og3 {
@@ -12,26 +13,31 @@ namespace {
 constexpr unsigned kCfgSet = VariableBase::Flags::kConfig | VariableBase::Flags::kSettable;
 }  // namespace
 
-const char* DoseLog::varname(const char* elname, const VariableGroup& vg, std::string* str) {
-  *str = std::string(vg.name()) + "_" + elname;
-  return str->c_str();
-}
-
-DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system)
+DoseLog::DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system,
+                 Watering* watering)
     : m_max_doses_per_cycle("max_doses_per_cycle", kMaxDosesPerCycle, "", "maximum doses per cycle",
                             kCfgSet, cfg_vg),
-      m_doses_this_cycle(varname("doses_this_cycle", vg, &m_str_doses_this_cycle), 0, "",
-                         "doses this cycle", 0, vg),
-      m_dose_count(varname("doses_today", vg, &m_str_doses_today), 0, "", "doses in the past day",
-                   0, vg),
-      m_module_system(module_system) {}
+      m_doses_this_cycle("doses_this_cycle", 0, "", "doses this cycle", 0, vg),
+      m_dose_count("doses_today", 0, "", "doses in the past day", 0, vg),
+      m_module_system(module_system),
+      m_watering(watering) {}
 
 void DoseLog::addHADiscovery(HADiscovery* had) {
-  had->addDiscoveryCallback([this](HADiscovery* had, JsonDocument* json) {
-    return had->addMeas(json, m_doses_this_cycle, ha::device_type::kSensor, nullptr);
+  auto addEntry = [this](HADiscovery::Entry& entry, HADiscovery* had, JsonDocument* json) {
+    char device_id[80];
+    snprintf(device_id, sizeof(device_id), "%s_%s", had->deviceId(), this->m_watering->name());
+    entry.device_name = this->m_watering->plantName().c_str();
+    entry.device_id = device_id;
+    return had->addEntry(json, entry);
+  };
+
+  had->addDiscoveryCallback([this, addEntry](HADiscovery* had, JsonDocument* json) {
+    HADiscovery::Entry entry(m_doses_this_cycle, ha::device_type::kSensor, nullptr);
+    return addEntry(entry, had, json);
   });
-  had->addDiscoveryCallback([this](HADiscovery* had, JsonDocument* json) {
-    return had->addMeas(json, m_dose_count, ha::device_type::kSensor, nullptr);
+  had->addDiscoveryCallback([this, addEntry](HADiscovery* had, JsonDocument* json) {
+    HADiscovery::Entry entry(m_dose_count, ha::device_type::kSensor, nullptr);
+    return addEntry(entry, had, json);
   });
 }
 
@@ -52,16 +58,16 @@ void DoseLog::addDose() {
 }
 
 void DoseLog::update(bool is_watering) {
-  if (m_watering != is_watering) {
+  if (m_is_watering != is_watering) {
     if (is_watering) {
       m_dose_record.pushBack({});
     } else {
       m_doses_this_cycle = 0;
     }
-    m_watering = is_watering;
+    m_is_watering = is_watering;
   }
 
-  if (!m_watering && !m_dose_record.empty()) {
+  if (!m_is_watering && !m_dose_record.empty()) {
     const int64_t now_secs = esp_timer_get_time() / kUsecInSec;
     const int64_t one_day_ago = std::max(static_cast<int64_t>(0), now_secs - kWateringPauseSec);
     while (!m_dose_record.empty()) {

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Chris Lee and contibuters.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
 #pragma once
 
 #include <og3/constants.h>

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -41,6 +41,9 @@ class DoseLog {
   Logger* log() { return m_module_system->log(); }
   const char* varname(const char* elname, const VariableGroup& vg, std::string* str);
 
+  std::string m_str_doses_this_cycle;
+  std::string m_str_doses_today;
+
   // The maximum number of doses to allow in a cycle/day before watering should be paused.
   Variable<unsigned> m_max_doses_per_cycle;
   // Number of doses in the current watering cycle.

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -34,6 +34,10 @@ class DoseLog {
 
  private:
   Logger* log() { return m_module_system->log(); }
+  const char* varname(const char* elname, const VariableGroup& vg, std::string* str);
+
+  std::string m_str_doses_this_cycle;
+  std::string m_str_doses_today;
 
   // The maximum number of doses to allow in a cycle/day before watering should be paused.
   Variable<unsigned> m_max_doses_per_cycle;

--- a/lib/watering/dose_log.h
+++ b/lib/watering/dose_log.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <og3/constants.h>
 #include <og3/module_system.h>
 #include <og3/ring_buffer.h>
@@ -8,12 +10,15 @@
 
 namespace og3 {
 
+class Watering;
+
 // Track the total number of watering doses in a day.
 // This is done to avoid over-watering in case something goes wrong such as problems
 //  reading the moisture level of the soil.
 class DoseLog {
  public:
-  DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system);
+  DoseLog(VariableGroup& vg, VariableGroup& cfg_vg, ModuleSystem* module_system,
+          Watering* watering);
 
   // Return the total number of doses in the last 24 hours.
   unsigned dose_count() const { return m_dose_count.value(); }
@@ -36,16 +41,13 @@ class DoseLog {
   Logger* log() { return m_module_system->log(); }
   const char* varname(const char* elname, const VariableGroup& vg, std::string* str);
 
-  std::string m_str_doses_this_cycle;
-  std::string m_str_doses_today;
-
   // The maximum number of doses to allow in a cycle/day before watering should be paused.
   Variable<unsigned> m_max_doses_per_cycle;
   // Number of doses in the current watering cycle.
   Variable<unsigned> m_doses_this_cycle;
   // Number of doses in the last 24 hours.
   Variable<unsigned> m_dose_count;
-  bool m_watering = false;
+  bool m_is_watering = false;
 
   // Doses in watering cycles in the last 24 hours.
   struct Dose {
@@ -56,6 +58,7 @@ class DoseLog {
   };
   RingQueue<Dose, 16> m_dose_record;
   ModuleSystem* m_module_system;  // Used to access the logger.
+  Watering* m_watering;
 };
 
 }  // namespace og3

--- a/lib/watering/moisture_sensor.cpp
+++ b/lib/watering/moisture_sensor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include "moisture_sensor.h"

--- a/lib/watering/moisture_sensor.h
+++ b/lib/watering/moisture_sensor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <og3/kernel_filter.h>

--- a/lib/watering/reservoir_check.cpp
+++ b/lib/watering/reservoir_check.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include "reservoir_check.h"

--- a/lib/watering/reservoir_check.h
+++ b/lib/watering/reservoir_check.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <og3/config_interface.h>

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -79,20 +79,26 @@ bool Watering::StateVariable::fromString(const String& value) {
   return false;
 }
 
+const char* Watering::varname(const char* elname, std::string* str) {
+  *str = std::string(name()) + "_" + elname;
+  return str->c_str();
+}
+
 Watering::Watering(unsigned index, const char* name, uint8_t moisture_pin, uint8_t mode_led,
                    uint8_t pump_ctl_pin, HAApp* app)
     : Module(name, &app->module_system()),
       m_app(app),
       m_dependencies({ConfigInterface::kName, ReservoirCheck::kName}),
       m_index(index),
-      m_cfg_vg(name, VariableGroup::VarNameType::kWithGroup),
-      m_vg(name, VariableGroup::VarNameType::kWithGroup),
+      m_cfg_vg(name),
+      m_vg(name),
       m_status_url(String("/") + name + "/status"),
       m_config_url(String("/") + name + "/config"),
       m_pump_test_url(String("/") + name + "/pump"),
-      m_moisture("soil_moisture", moisture_pin, "raw moisture reading", "soil moisture %",
-                 &app->module_system(), m_cfg_vg, m_vg),
-      m_pump("pump", &app->tasks(), pump_ctl_pin, "pump state", true, m_vg, Relay::OnLevel::kHigh),
+      m_moisture(varname("soil_moisture", &m_moisture_varname), moisture_pin,
+                 "raw moisture reading", "soil moisture %", &app->module_system(), m_cfg_vg, m_vg),
+      m_pump(varname("pump", &m_pump_varname), &app->tasks(), pump_ctl_pin, "pump state", true,
+             m_vg, Relay::OnLevel::kHigh),
       m_mode_led("mode_led", mode_led, app, 100 /*msec-on*/, false /*onLow*/),
       m_dose_log(m_vg, m_cfg_vg, &app->module_system()),
       m_max_moisture_target("max_moisture_target", 80.0f, units::kPercentage, "Max moisture",
@@ -103,8 +109,10 @@ Watering::Watering(unsigned index, const char* name, uint8_t moisture_pin, uint8
                        kCfgSet, 0, m_cfg_vg),
       m_between_doses_sec("between_doses_sec", kPumpOffSec, units::kSeconds, "Wait between doses",
                           kCfgSet, 0, m_cfg_vg),
-      m_state("watering_state", kStateWaitForNextCycle, "watering state", 0, m_vg),
-      m_sec_since_dose("sec_since_pump", 0, units::kSeconds, "seconds since pump dose", 0, 0, m_vg),
+      m_state(varname("watering_state", &m_watering_varname), kStateWaitForNextCycle,
+              "watering state", 0, m_vg),
+      m_sec_since_dose(varname("sec_since_pump", &m_sec_dose_varname), 0, units::kSeconds,
+                       "seconds since pump dose", 0, 0, m_vg),
       m_watering_enabled("watering_enabled", false, "watering enabled", kCfgSet, m_cfg_vg),
       m_reservoir_check_enabled("res_check_enabled", false, "reservior check enabled", kCfgSet,
                                 m_cfg_vg) {

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -139,6 +139,7 @@ Watering::Watering(unsigned index, const char* name, uint8_t moisture_pin, uint8
       snprintf(device_id, sizeof(device_id), "%s_%s", had->deviceId(), this->name());
       entry.device_name = this->plantName().c_str();
       entry.device_id = device_id;
+      entry.via_device = had->deviceId();
       return had->addEntry(json, entry);
     };
 

--- a/lib/watering/watering.cpp
+++ b/lib/watering/watering.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include "watering.h"

--- a/lib/watering/watering.h
+++ b/lib/watering/watering.h
@@ -101,6 +101,8 @@ class Watering : public Module {
   const char* statusUrl() const { return m_status_url.c_str(); }
   const char* configUrl() const { return m_config_url.c_str(); }
   const char* pumpTestUrl() const { return m_pump_test_url.c_str(); }
+  const char* varname(const char* name, std::string* str);
+
   void handleStatusRequest(AsyncWebServerRequest* request);
   void handleConfigRequest(AsyncWebServerRequest* request);
 
@@ -113,6 +115,12 @@ class Watering : public Module {
   const String m_config_url;
   const String m_pump_test_url;
   String m_html;
+
+  std::string m_moisture_varname;
+  std::string m_pump_varname;
+  std::string m_watering_varname;
+  std::string m_sec_dose_varname;
+
   ReservoirCheck* m_reservoir_check = nullptr;
   ConfigInterface* m_config = nullptr;
   MoistureSensor m_moisture;

--- a/lib/watering/watering.h
+++ b/lib/watering/watering.h
@@ -1,3 +1,4 @@
+#pragma once
 // Copyright (c) 2024 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
@@ -76,13 +77,17 @@ class Watering : public Module {
   float maxTarget() const { return m_max_moisture_target.value(); }
   float minTarget() const { return m_min_moisture_target.value(); }
 
+  const String& plantName() const { return m_plant_name.value(); }
+
   void setPumpEnable(bool enable);
   void setReservoirCheckEnable(bool enable) { m_reservoir_check_enabled = enable; }
   bool reservoirCheckEnabled() const { return m_reservoir_check_enabled.value(); }
   void testPump() { setState(kStatePumpTest, 100, "test pump"); }
   void test() { setState(kStateTest, 100, "full test"); }
   State state() const { return static_cast<State>(m_state.value()); }
-  void add_html_status_button(String* body) const { add_html_button(body, name(), statusUrl()); }
+  void add_html_status_button(String* body) const {
+    add_html_button(body, plantName().c_str(), statusUrl());
+  }
   bool isReservoirEmpty() const { return !m_reservoir_check->haveWater(); }
 
   const VariableGroup& variables() const { return m_vg; }
@@ -116,6 +121,7 @@ class Watering : public Module {
   const String m_pump_test_url;
   String m_html;
 
+  std::string m_device_id;
   std::string m_moisture_varname;
   std::string m_pump_varname;
   std::string m_watering_varname;
@@ -129,6 +135,7 @@ class Watering : public Module {
   DoseLog m_dose_log;
 
   unsigned long m_next_update_msec = 0;
+  Variable<String> m_plant_name;
   FloatVariable m_max_moisture_target;
   FloatVariable m_min_moisture_target;
   FloatVariable m_pump_dose_msec;

--- a/lib/watering/watering.h
+++ b/lib/watering/watering.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <og3/blink_led.h>

--- a/lib/watering/watering_constants.h
+++ b/lib/watering/watering_constants.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <og3/units.h>

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@
 [platformio]
 extra_configs =
 	      secrets.ini
-;	      secrets-usb.ini
-	      secrets-ota.ini
+	      secrets-usb.ini
+;	      secrets-ota.ini
 
 [env:node32s]
 platform = espressif32

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,12 +28,13 @@ build_type = release
 ;	~/Projects2/Plant133/lib/watering
 lib_deps =
 ;        watering
-	og3@^0.3.19
+	og3@^0.3.21
 	og3x-oled@^0.3.1
 	og3x-shtc3@^0.3.0
 	adafruit/Adafruit BusIO
 	adafruit/Adafruit SHTC3 Library
 	adafruit/Adafruit Unified Sensor
+	bakercp/CRC32
 	bblanchon/ArduinoJson@^7.0.0
 	heman/AsyncMqttClient-esphome@^1.0.0
 	esphome/ESPAsyncWebServer-esphome@^3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,10 +27,10 @@ build_type = release
 ;	~/Projects2
 ;	~/Projects2/Plant133/lib/watering
 lib_deps =
-        watering
-	og3@^0.2.5
-	og3x-oled@^0.2.3
-	og3x-shtc3@^0.2.0
+;        watering
+	og3@^0.3.19
+	og3x-oled@^0.3.1
+	og3x-shtc3@^0.3.0
 	adafruit/Adafruit BusIO
 	adafruit/Adafruit SHTC3 Library
 	adafruit/Adafruit Unified Sensor
@@ -45,7 +45,7 @@ build_flags =
 	'-Wall'
 	'-D OTA_PASSWORD="${secrets.otaPassword}"'
 ;	'-D LOG_DEBUG'
-;	'-D LOG_UDP'
+	'-D LOG_UDP'
 	'-D WIFI_OLED'
 	'-D LOG_UDP_ADDRESS=${secrets.udpLogTarget}'
 	'-D AP_PASSWORD="${secrets.apPassword}"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@
 [platformio]
 extra_configs =
 	      secrets.ini
-	      secrets-usb.ini
-;	      secrets-ota.ini
+;	      secrets-usb.ini
+	      secrets-ota.ini
 
 [env:node32s]
 platform = espressif32

--- a/scad/box/Plant1337_test.scad
+++ b/scad/box/Plant1337_test.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <board.scad>

--- a/scad/box/board.scad
+++ b/scad/box/board.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <ProjectBox/project_box.scad>

--- a/scad/box/box.scad
+++ b/scad/box/box.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <ProjectBox/project_box.scad>

--- a/scad/box/box_bottom.scad
+++ b/scad/box/box_bottom.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <box.scad>

--- a/scad/box/box_top.scad
+++ b/scad/box/box_top.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <box.scad>

--- a/scad/box/gui.scad
+++ b/scad/box/gui.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 // :GUI:

--- a/scad/ebox_hook/hook.scad
+++ b/scad/ebox_hook/hook.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <../box/board.scad>

--- a/scad/ebox_hook/print_hook.scad
+++ b/scad/ebox_hook/print_hook.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <hook.scad>

--- a/scad/moisture_sensor_cap/box.scad
+++ b/scad/moisture_sensor_cap/box.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <moisture_sensor.scad>

--- a/scad/moisture_sensor_cap/box_bottom.scad
+++ b/scad/moisture_sensor_cap/box_bottom.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <box.scad>

--- a/scad/moisture_sensor_cap/box_top.scad
+++ b/scad/moisture_sensor_cap/box_top.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <box.scad>

--- a/scad/moisture_sensor_cap/moisture_sensor.scad
+++ b/scad/moisture_sensor_cap/moisture_sensor.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <MCAD/units.scad>

--- a/scad/moisture_sensor_cap/sensor_test.scad
+++ b/scad/moisture_sensor_cap/sensor_test.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <moisture_sensor.scad>

--- a/scad/moisture_sensor_cap/test.scad
+++ b/scad/moisture_sensor_cap/test.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 //include <board.scad>

--- a/scad/reservoir_insert/gui.scad
+++ b/scad/reservoir_insert/gui.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 // :GUI:

--- a/scad/reservoir_insert/insert_print.scad
+++ b/scad/reservoir_insert/insert_print.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <gui.scad>

--- a/scad/reservoir_insert/insert_test.scad
+++ b/scad/reservoir_insert/insert_test.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <gui.scad>

--- a/scad/reservoir_insert/insert_top_print.scad
+++ b/scad/reservoir_insert/insert_top_print.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <reservoir_insert.scad>

--- a/scad/reservoir_insert/reservoir_insert.scad
+++ b/scad/reservoir_insert/reservoir_insert.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <MCAD/units.scad>

--- a/scad/spike/spike.scad
+++ b/scad/spike/spike.scad
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 include <MCAD/units.scad>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <Arduino.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,12 +16,12 @@
 
 #include "watering.h"
 
-#define SW_VERSION "0.8.1"
+#define SW_VERSION "0.8.2"
 
 namespace {
 
 const char kManufacturer[] = "Chris Lee";
-const char kModel[] = "Plantl337a";
+const char kModel[] = "Plantl337";
 const char kSoftware[] = "PlantL33 " SW_VERSION;
 
 // -- Hardware configuration,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 
 #include "watering.h"
 
-#define SW_VERSION "0.8.2"
+#define SW_VERSION "0.8.3"
 
 namespace {
 

--- a/test/test_watering/test_watering.cpp
+++ b/test/test_watering/test_watering.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <ArduinoFake.h>

--- a/util/license_header.txt
+++ b/util/license_header.txt
@@ -1,2 +1,2 @@
-// Copyright (c) 2024 Chris Lee and contibuters.
+// Copyright (c) 2025 Chris Lee and contibuters.
 // Licensed under the MIT license. See LICENSE file in the project root for details.


### PR DESCRIPTION
The Home Assistant MQTT-based discovery now makes separate "plant" devices for each plant, with a parent device which is the Plant133 device.  Plant-devices are named via config so that they can show up as "cactus" or whatever instead of being a group of sensor readings with "plant1_" etc... appended to their names.